### PR TITLE
add a new option to qa_plot.py and a new script chr_remover.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Installation
 
 **Required dependencies**
 
-- Python version >=2.6
+- Python version >=2.7
 
 - GNU linear programming kit `GLPK <http://www.gnu.org/software/glpk/>`_.
 
@@ -81,7 +81,7 @@ Cookbook
 -------------------------
 Default package comes with the test data for case 1 and 2 in ``run.sh``. More
 test data set can be downloaded `here
-<http://chibba.agtec.uga.edu/duplication/data/quota-align-test.tar.gz>`_.
+<http://chibba.agtec.uga.edu/duplication/index/downloads/>`_.
 Unpack into the folder, and execute ``run.sh``.
 
 BLAST anchors chaining and quota-based screening

--- a/scripts/chr_remover.py
+++ b/scripts/chr_remover.py
@@ -1,0 +1,53 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import re
+
+"""
+this script aims to remove the specified chromosome(s) in bed and pep file.
+you can specify a exact name of a chromosome or use a regular expression.
+"""
+
+def handle_bed(infile, chrname):
+    genelist, out_list = [], []
+    with open(infile, 'r') as f:
+        for line in f:
+            ls = line.split('\t')
+            if re.findall(chrname, ls[0]):
+                genelist.append(ls[3])
+            else:
+                out_list.append(line)
+    with open(infile+'.'+chrname+'_removed', 'w') as f:
+        f.writelines(out_list)
+    return genelist
+
+def handle_pep(infile, genelist, chrname):
+    out_list = []
+    with open(infile, 'r') as f:
+        for line in f:
+            if line[0] == '>' and line.split(' ')[0][1:] in genelist:
+                flag = 0
+            elif line[0] == '>':
+                out_list.append(line)
+                flag = 1
+            elif flag:
+                out_list.append(line)
+    with open(infile+'.'+chrname+'_removed', 'w') as f:
+        f.writelines(out_list)
+    
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('bedfile', 
+            help='input bed file name')
+    parser.add_argument('pepfile',
+            help='input pep file name')
+    parser.add_argument('chrname',
+            help='a regular expression which matches the chromosome you want to remove')
+    args = parser.parse_args()
+
+    gene_list = handle_bed(args.bedfile, args.chrname)
+    handle_pep(args.pepfile, gene_list, args.chrname)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/chr_remover.py
+++ b/scripts/chr_remover.py
@@ -5,8 +5,8 @@ import argparse
 import re
 
 """
-this script aims to remove the specified chromosome(s) in bed and pep file.
-you can specify a exact name of a chromosome or use a regular expression.
+This script aims to remove the specified chromosome(s) in bed and pep file.
+You can remove a chromosome or a set of chromosomes by using a regular expression.
 """
 
 def handle_bed(infile, chrname):

--- a/scripts/qa_plot.py
+++ b/scripts/qa_plot.py
@@ -62,7 +62,7 @@ def draw_box(fp, ax, color="b"):
                                 ec=color, fill=False, lw=.2))
 
 
-def dotplot(qa_file, qbed, sbed, image_name, bpscale=False, remove=""):
+def dotplot(qa_file, qbed, sbed, image_name, bpscale=False, remove=None):
 
     qa = Raw(qa_file)
     qa_fh = file(qa_file)
@@ -143,9 +143,10 @@ if __name__ == "__main__":
             help="Use actual bp position in bed file [default: %default]")
     parser.add_option("--outfmt", default="png",
             help="format of output plot. support: png, pdf, ps, eps and svg [default: %default]")
-    parser.add_option("--remove", default="",
-            help="remove chromosome breaks and labels from query genome (--remove=q) or \
-            subject genome (--remove=s) or both (--remove=qs) [default: %default]")
+    parser.add_option("--remove", default=None,
+            help="remove chromosome breaks and labels from query genome \
+            (--remove=q) or from subject genome (--remove=s) or from \
+            both of them (--remove=qs) [default: %default]")
     
     (options, args) = parser.parse_args()
 

--- a/scripts/qa_plot.py
+++ b/scripts/qa_plot.py
@@ -62,7 +62,7 @@ def draw_box(fp, ax, color="b"):
                                 ec=color, fill=False, lw=.2))
 
 
-def dotplot(qa_file, qbed, sbed, image_name, bpscale=False):
+def dotplot(qa_file, qbed, sbed, image_name, bpscale=False, remove=""):
 
     qa = Raw(qa_file)
     qa_fh = file(qa_file)
@@ -85,24 +85,28 @@ def dotplot(qa_file, qbed, sbed, image_name, bpscale=False):
 
     xchr_labels, ychr_labels = [], []
     # plot the chromosome breaks
-    for (seqid, beg, end) in get_breaks(qbed, bpscale=bpscale):
-        xchr_labels.append((seqid, (beg + end)/2))
-        ax.plot([beg, beg], ylim, "g-", alpha=.5)
+    if remove not in ("qs", "sq", "q"):
+        for (seqid, beg, end) in get_breaks(qbed, bpscale=bpscale):
+            xchr_labels.append((seqid, (beg + end)/2))
+            ax.plot([beg, beg], ylim, "g-", alpha=.5)
 
-    for (seqid, beg, end) in get_breaks(sbed, bpscale=bpscale):
-        ychr_labels.append((seqid, (beg + end)/2))
-        ax.plot(xlim, [beg, beg], "g-", alpha=.5)
+    if remove not in ("qs", "sq", "s"):
+        for (seqid, beg, end) in get_breaks(sbed, bpscale=bpscale):
+            ychr_labels.append((seqid, (beg + end)/2))
+            ax.plot(xlim, [beg, beg], "g-", alpha=.5)
 
     # plot the chromosome labels
-    for label, pos in xchr_labels:
-        pos = .1 + pos * .8/xlim[1]
-        root.text(pos, .93, r"%s" % label, color="b",
-            size=9, alpha=.5, rotation=45)
+    if remove not in ("qs", "sq", "q"):
+        for label, pos in xchr_labels:
+            pos = .1 + pos * .8/xlim[1]
+            root.text(pos, .93, r"%s" % label, color="b",
+                size=9, alpha=.5, rotation=45)
 
-    for label, pos in ychr_labels:
-        pos = .1 + pos * .8/ylim[1]
-        root.text(.91, pos, r"%s" % label, color="b",
-            size=9, alpha=.5, ha="left", va="center")
+    if remove not in ("qs", "sq", "s"):
+        for label, pos in ychr_labels:
+            pos = .1 + pos * .8/ylim[1]
+            root.text(.91, pos, r"%s" % label, color="b",
+                size=9, alpha=.5, ha="left", va="center")
 
     ax.set_xlim(xlim)
     ax.set_ylim(ylim)
@@ -139,7 +143,10 @@ if __name__ == "__main__":
             help="Use actual bp position in bed file [default: %default]")
     parser.add_option("--outfmt", default="png",
             help="format of output plot. support: png, pdf, ps, eps and svg [default: %default]")
-
+    parser.add_option("--remove", default="",
+            help="remove chromosome breaks and labels from query genome (--remove=q) or \
+            subject genome (--remove=s) or both (--remove=qs) [default: %default]")
+    
     (options, args) = parser.parse_args()
 
     if not (len(args) == 1 and options.qbed and options.sbed):
@@ -151,4 +158,4 @@ if __name__ == "__main__":
     qa_file = args[0]
 
     image_name = op.splitext(qa_file)[0] + "." + options.outfmt
-    dotplot(qa_file, qbed, sbed, image_name, bpscale=options.bpscale)
+    dotplot(qa_file, qbed, sbed, image_name, bpscale=options.bpscale, remove=options.remove)


### PR DESCRIPTION
### a new option `--remove`:
In many cases, the scaffolds and contigs are not assembled to pseudo-molecules. The chromosome breaks and labels of scaffolds and contigs will be stacked up. Here, I add a new option `--remove`, to remove the chromosome breaks and labels from the query genome (`--remove=q`) or from the subject genome (`--remove=s`) or from both of them (`--remove=qs`).

I think the option is very useful and make the script more flexible :)

### chr_remover.py:
This script aims to remove the specified chromosome(s) in bed and pep file.  It can remove a chromosome or a set of chromosomes by using a regular expression.

For example: 
There are chromosomes named "unknown" and "_random" in the grape genome (the dotplot example in `README.rst`). Sometimes we don't need them. This script can remove them from bed and pep file. If I want to remove all "_random" chromosomes, just do this:
```
python chr_remover.py Vvi.bed Vvi.pep random
```
If I want to remove chr1 but not remove chr10 - chr19, just do this:
```
python chr_remover.py Vvi.bed Vvi.pep chr1$
```
This script uses `argparse`, if you don't like it, I can rewrite it using `optparse`

### README.rst:
1. argparse needs python2.7
2. the url of test data set is invalid